### PR TITLE
Fix: Remove default TARGETPLATFORM and BUILDPLATFORM in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # See: https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/docker/building-net-docker-images?view=aspnetcore-6.0#the-dockerfile
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
-ARG TARGETPLATFORM=linux/amd64
-ARG BUILDPLATFORM=linux/amd64
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
 WORKDIR /source


### PR DESCRIPTION
These are variables passed in from `docker buildx` which are not needed when using `docker build` (not `buildx`).